### PR TITLE
Fix submodules not installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
     "Js2Py~=0.74",
 ]
 
-[tool.setuptools]
-packages = ["pyfbsdk_stub_generator"]
+[tool.setuptools.packages.find]
+where = ["."]
 
 [tool.setuptools.package-data]
 include = ["pyfbsdk_stub_generator/**"]


### PR DESCRIPTION
Hi @nils-soderman,

I could not generate stub myself and I found that it was because `pip install` did not install `pyfbsdk_stub_generator.plugins` and `pyfbsdk_stub_generator.base_content`.

Hence this PR.

Thanks for this generator 🚀 
